### PR TITLE
perl-5.26.0 compatibility

### DIFF
--- a/t/04tie.t
+++ b/t/04tie.t
@@ -16,8 +16,8 @@ print "ok 1\n";
 
 my $test = 2;
 
-require 't/dump.pl';
-require 't/tied.pl';
+require './t/dump.pl';
+require './t/tied.pl';
 
 my ($a, @a, %a);
 tie $a, TIED_SCALAR;

--- a/t/dclone.t
+++ b/t/dclone.t
@@ -40,7 +40,7 @@
 # Baseline for first beta release.
 #
 
-require 't/dump.pl';
+require './t/dump.pl';
 
 # use Storable qw(dclone);
 use Clone::PP qw(clone);

--- a/t/tied.pl
+++ b/t/tied.pl
@@ -35,7 +35,7 @@
 # Baseline for first beta release.
 #
 
-require 't/dump.pl';
+require './t/dump.pl';
 
 package TIED_HASH;
 


### PR DESCRIPTION
In Perl 5.26.0, '.' will no longer be found by default in @INC.  This patch
adjusts three test files so that file './t/dump.pl' is correctly located.

For:  https://rt.cpan.org/Ticket/Display.html?id=120522